### PR TITLE
setup: exclude tests for default install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author = 'VeNoMouS',
     author_email = 'venom@gen-x.co.nz',
     version=VERSION,
-    packages = find_packages(),
+    packages = find_packages(exclude=['tests*']),
     description = 'A Python module to bypass Cloudflare\'s anti-bot page.',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
We probably don't need install tests for "normal" users and this is required to get gentoo ebuild working (package manager).

ps. You forgot to push new release/archive on github - latest is 1.2.9