### PR TITLE
Ugly fix for fake jsch_vc, pass params

### DIFF
--- a/cloudscraper/__init__.py
+++ b/cloudscraper/__init__.py
@@ -322,7 +322,9 @@ class CloudScraper(Session):
                 body, re.M | re.DOTALL
             ).groupdict().get('challengeUUID', '')
 
-            payload = OrderedDict(re.findall(r'name="(r|jschl_vc|pass)"\svalue="(.*?)"', body))
+            payload = re.findall(r'name="(r|jschl_vc|pass)"\svalue="(.*?)"', body)
+            payload.reverse()
+            payload = OrderedDict(payload)
 
         except AttributeError:
             sys.tracebacklimit = 0


### PR DESCRIPTION
They started to include second fake form with bad params that we have to ignore. Challenge html code:
https://gist.github.com/oczkers/b4f7408e81c70b9b32643690d2caf19e
website: https://takefile.link

OrderedDict uses only last value when there are duplicate keys so we ended up with jschl_vc=1, pass=""
I've fixed it by reversing list before converting list->OrderedDict so now it uses first seen values instead of last seen. It worked for this site but can be easly changed in future probably so this is ugly fix and You probably don't want to merge this - we should use sth more bulletproof like loop checking params one by one or cutting part of html code before regex etc.
