### PR TITLE
Allow replacing actual call to perform HTTP request via subclassing

### DIFF
--- a/cloudscraper/__init__.py
+++ b/cloudscraper/__init__.py
@@ -157,6 +157,15 @@ class CloudScraper(Session):
     def __getstate__(self):
         return self.__dict__
 
+
+    # ------------------------------------------------------------------------------- #
+    # Allow replacing actual web request call via subclassing
+    # ------------------------------------------------------------------------------- #
+
+    def perform_request(self, method, url, *args, **kwargs):
+
+        return super(CloudScraper, self).request(method, url, *args, **kwargs)
+
     # ------------------------------------------------------------------------------- #
     # Raise an Exception with no stacktrace and reset depth counter.
     # ------------------------------------------------------------------------------- #
@@ -236,7 +245,7 @@ class CloudScraper(Session):
         # ------------------------------------------------------------------------------- #
 
         response = self.decodeBrotli(
-            super(CloudScraper, self).request(method, url, *args, **kwargs)
+            self.perform_request(method, url, *args, **kwargs)
         )
 
         # ------------------------------------------------------------------------------- #
@@ -517,7 +526,7 @@ class CloudScraper(Session):
             # ------------------------------------------------------------------------------- #
 
             resp = self.decodeBrotli(
-                super(CloudScraper, self).request(resp.request.method, resp.url, **kwargs)
+                self.perform_request(resp.request.method, resp.url, **kwargs)
             )
 
             if not self.is_reCaptcha_Challenge(resp):

--- a/cloudscraper/__init__.py
+++ b/cloudscraper/__init__.py
@@ -157,13 +157,11 @@ class CloudScraper(Session):
     def __getstate__(self):
         return self.__dict__
 
-
     # ------------------------------------------------------------------------------- #
     # Allow replacing actual web request call via subclassing
     # ------------------------------------------------------------------------------- #
 
     def perform_request(self, method, url, *args, **kwargs):
-
         return super(CloudScraper, self).request(method, url, *args, **kwargs)
 
     # ------------------------------------------------------------------------------- #


### PR DESCRIPTION
Basically, I have my own urllib wrapper that I'm maintaining almost entirely out of spite. It has it's own cookie/UA/header/etc... management, and I'd like to be able to just wrap that instead of having to move things back and forth between it and the requests session continuously. 

This change basically moves the actual calls to the parent  `super().request()` call into a stub function, so I can subclass `CloudScraper()`, and then just replace the body of `perform_request()` with my own HTTP fetching machinery. 

I'm not sure this is something of interest to really anyone other then myself, but it's also a really simple change (and could potentially be useful for testing purposes/mocking as well). Being able to plug in any arbitrary HTTP(s) transport seems like a nice feature too.