### PR TITLE
Async integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Alternatively, clone this repository and run `python setup.py install`.
 - Python 3.x
 - **[Requests](https://github.com/kennethreitz/requests)** >= 2.9.2
 - **[requests_toolbelt](https://pypi.org/project/requests-toolbelt/)** >= 0.9.1
+or
+- **[aiohttp](https://github.com/aio-libs/aiohttp)** >= ...
 
 `python setup.py install` will install the Python dependencies automatically. The javascript interpreters and/or engines you decide to use are the only things you need to install yourself, excluding js2py which is part of the requirements as the default.
 


### PR DESCRIPTION
As it is not possible to create issues I'll ask here.

I am coming from [aiocfscrape](https://github.com/pavlodvornikov/aiocfscrape) which was an async approach/reimplementation of [cfscrape](https://github.com/Anorov/cloudflare-scrape). `cfscrape` seems to be dead nowadays. Thus `aiocfscrape` would now do the bypassing by itself or rebasing on a new project. Either way, it would need to be rewritten. 

But as you seem to be fond of supporting various environments (eg. multiple different JS engine and captcha services).

Thus I propose to add async support with `aiohttp` directly to this repo instead of leeching off this one.

Architecturally I'd put the different implementations (requests, aiohttp) similarly as the JS engine and captcha service into one place, where then the user can say he wants either one of them. The difference would be however that the user can tell the session `async=True` and it'll then get the async implementation instead of the requests one. Another way would be to just create a new module and tell the user to import from `...async.CloudScraper` instead. 
This would also need second implementations of eg. the node js engine as we'd have to use [async subprocesses](https://docs.python.org/3/library/asyncio-subprocess.html) instead of the usual one.

This would also mean the python version compatibility wouldn't be 3.x but rather at least 3.5.x or rather even 3.6 as 3.5 actually [reached its end of life](https://pythoninsider.blogspot.com/2020/10/python-35-is-no-longer-supported.html).

I'd be glad to create/maintain the async implementation.