### PR TITLE
Added parameter to change the type of encryption used

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Or
 |desktop|(boolean)|True|
 |platform|(string) `'linux', 'windows', 'darwin', 'android', 'ios'`|None|
 |custom|(string)|None|
+|ecdhCurve|(string)|prime256v1|
 #### Example
 
 ```python
@@ -186,7 +187,7 @@ scraper = cloudscraper.create_scraper(
     }
 )
 
-# Some servers require the use of a more complex ecdh curve than the default "prime256v1", to change the encryption type use the ecdhCurve parameter
+# Some servers require the use of a more complex ecdh curve than the default "prime256v1"
 # It may can solve handshake failure
 scraper = cloudscraper.create_scraper(
     ecdhCurve='secp384r1'

--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ scraper = cloudscraper.create_scraper(
         'custom': 'ScraperBot/1.0',
     }
 )
+
+# Some servers require the use of a more complex ecdh curve than the default "prime256v1", to change the encryption type use the ecdhCurve parameter
+# It may can solve handshake failure
+scraper = cloudscraper.create_scraper(
+    ecdhCurve='secp384r1'
+)
 ```
 ------
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ Or
 |desktop|(boolean)|True|
 |platform|(string) `'linux', 'windows', 'darwin', 'android', 'ios'`|None|
 |custom|(string)|None|
-|ecdhCurve|(string)|prime256v1|
 #### Example
 
 ```python
@@ -185,12 +184,6 @@ scraper = cloudscraper.create_scraper(
     browser={
         'custom': 'ScraperBot/1.0',
     }
-)
-
-# Some servers require the use of a more complex ecdh curve than the default "prime256v1"
-# It may can solve handshake failure
-scraper = cloudscraper.create_scraper(
-    ecdhCurve='secp384r1'
 )
 ```
 ------
@@ -601,5 +594,29 @@ print(
         ),
         shell=True
     )
+)
+```
+
+### Cryptography
+
+#### Description
+
+Control communication between client and server
+
+#### Parameters
+
+Can be passed as an argument to `create_scraper()`.
+
+|Parameter|Value|Default|
+|-------------|:-------------:|:-----:|
+|cipherSuite|(string)|None|
+|ecdhCurve|(string)|prime256v1|
+#### Example
+
+```python
+# Some servers require the use of a more complex ecdh curve than the default "prime256v1"
+# It may can solve handshake failure
+scraper = cloudscraper.create_scraper(
+    ecdhCurve='secp384r1'
 )
 ```

--- a/cloudscraper/__init__.py
+++ b/cloudscraper/__init__.py
@@ -79,6 +79,7 @@ class CipherSuiteAdapter(HTTPAdapter):
         self.ssl_context = kwargs.pop('ssl_context', None)
         self.cipherSuite = kwargs.pop('cipherSuite', None)
         self.source_address = kwargs.pop('source_address', None)
+        self.ecdhCurve = kwargs.pop('ecdhCurve', 'prime256v1')
 
         if self.source_address:
             if isinstance(self.source_address, str):
@@ -92,7 +93,7 @@ class CipherSuiteAdapter(HTTPAdapter):
         if not self.ssl_context:
             self.ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
             self.ssl_context.set_ciphers(self.cipherSuite)
-            self.ssl_context.set_ecdh_curve('prime256v1')
+            self.ssl_context.set_ecdh_curve(self.ecdhCurve)
             self.ssl_context.options |= (ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1)
 
         super(CipherSuiteAdapter, self).__init__(**kwargs)
@@ -120,6 +121,7 @@ class CloudScraper(Session):
         self.debug = kwargs.pop('debug', False)
         self.delay = kwargs.pop('delay', None)
         self.cipherSuite = kwargs.pop('cipherSuite', None)
+        self.ecdhCurve = kwargs.pop('ecdhCurve', 'prime256v1')
         self.ssl_context = kwargs.pop('ssl_context', None)
         self.interpreter = kwargs.pop('interpreter', 'native')
         self.captcha = kwargs.pop('captcha', {})
@@ -159,6 +161,7 @@ class CloudScraper(Session):
             'https://',
             CipherSuiteAdapter(
                 cipherSuite=self.cipherSuite,
+                ecdhCurve=self.ecdhCurve,
                 ssl_context=self.ssl_context,
                 source_address=self.source_address
             )


### PR DESCRIPTION
I was having problems to perform the handshake with some servers because it is using 384bit encryption, so I found a type that solves my problem the "secp384r1". I added the possibility for the user to choose the best algorithm for each use.

The main problem I had was handshake errors like:
`(Caused by SSLError(SSLError(1, '[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE]) sslv3 alert handshake failure (_ssl.c:1108)'))`