### PR TITLE
Always share attributes with underlying session instance

### DIFF
--- a/cloudscraper/__init__.py
+++ b/cloudscraper/__init__.py
@@ -761,7 +761,7 @@ class CloudScraper(Session):
         if sess:
             for attr in ['auth', 'cert', 'cookies', 'headers', 'hooks', 'params', 'proxies', 'data']:
                 val = getattr(sess, attr, None)
-                if val:
+                if val is not None:
                     setattr(scraper, attr, val)
 
         return scraper


### PR DESCRIPTION
When an existing session instance was passed into create_scraper,
interesting attributes were copied if they were truthy. However, this
excluded copying attributes of mutable data types that were falsey at
the time. For example, if the cookie jar of the original session was
empty, then cloudscraper wouldn't use the same jar as the original
session and cookies would get out of sync between the two.

Now all interesting attributes are synced given they aren't None.