### PR TITLE
fix: Add missing comma in `get_tokens`

### DIFF
--- a/cloudscraper/__init__.py
+++ b/cloudscraper/__init__.py
@@ -782,7 +782,7 @@ class CloudScraper(Session):
                     'doubleDown',
                     'captcha',
                     'interpreter',
-                    'source_address'
+                    'source_address',
                     'requestPreHook',
                     'requestPostHook'
                 ] if field in kwargs


### PR DESCRIPTION
* This comma has been most probably been left out unintentionally, leading to string concatenation between the two consecutive lines. This issue has been found automatically using a regular expression.