### PR TITLE
Fix Python 3.10 ssl Deprecation Warning

### DIFF
--- a/cloudscraper/__init__.py
+++ b/cloudscraper/__init__.py
@@ -38,6 +38,16 @@ from .user_agent import User_Agent
 
 # ------------------------------------------------------------------------------- #
 
+# Avoid DeprecationWarning in Python 3.10. According to the warning OP_NO_SSL*
+# should be deprecated as well, but only the OP_NO_TLS* options actually trigger
+# the warning.
+if sys.version_info[:2] == (3, 10):
+    ssl_context_options = (ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3)
+else:
+    ssl_context_options = (ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1)
+
+# ------------------------------------------------------------------------------- #
+
 __version__ = '1.2.69'
 
 # ------------------------------------------------------------------------------- #
@@ -82,7 +92,7 @@ class CipherSuiteAdapter(HTTPAdapter):
 
             self.ssl_context.set_ciphers(self.cipherSuite)
             self.ssl_context.set_ecdh_curve(self.ecdhCurve)
-            self.ssl_context.options |= (ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1)
+            self.ssl_context.options |= ssl_context_options
 
         super(CipherSuiteAdapter, self).__init__(**kwargs)
 


### PR DESCRIPTION
Squash this `DeprecationWarning`:

```
Python 3.10.10 (main, Feb 16 2023, 02:55:02) [Clang 14.0.0 (clang-1400.0.29.202)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.7.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import ssl

In [2]: ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)

In [3]: ctx.options |= ssl.OP_NO_SSLv3

In [4]: ctx.options |= ssl.OP_NO_SSLv2

In [5]: ctx.options |= ssl.OP_NO_TLSv1
<ipython-input-8-791bbefea16b>:1: DeprecationWarning: ssl.OP_NO_SSL*/ssl.OP_NO_TLS* options are deprecated
  ctx.options |= ssl.OP_NO_TLSv1

In [6]: ctx.options |= ssl.OP_NO_TLSv1_1
<ipython-input-9-55e0d93abf34>:1: DeprecationWarning: ssl.OP_NO_SSL*/ssl.OP_NO_TLS* options are deprecated
  ctx.options |= ssl.OP_NO_TLSv1_1
  ```