### PR TITLE
Include tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE README.md cloudscraper/user_agent/browsers.json
+recursive-include tests *.py *.html


### PR DESCRIPTION
Include test files in sdist archives to make them usable for distribution maintainers.