### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     version=VERSION,
     packages = find_packages(exclude=['tests*']),
     description = 'A Python module to bypass Cloudflare\'s anti-bot page.',
+    license='MIT',
     long_description=readme,
     long_description_content_type='text/markdown',
     url = 'https://github.com/venomous/cloudscraper',


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.


Another topic:
Please consider to enable "Issues" in the repo. Would simplify the process of giving feedback like that currently the source is no tagged (causes problem for all distribution which were using the GitHub releases to build their packages).