### PR TITLE
Support loading browsers.json from zip archive

### DIFF
--- a/cloudscraper/user_agent/__init__.py
+++ b/cloudscraper/user_agent/__init__.py
@@ -1,11 +1,13 @@
 import json
-import os
+import pathlib
 import random
 import re
 import sys
 import ssl
 
 from collections import OrderedDict
+from importlib import resources
+
 
 # ------------------------------------------------------------------------------- #
 
@@ -71,7 +73,12 @@ class User_Agent():
             sys.tracebacklimit = 0
             raise RuntimeError("Sorry you can't have mobile and desktop disabled at the same time.")
 
-        with open(os.path.join(os.path.dirname(__file__), 'browsers.json'), 'r') as fp:
+        if sys.version >= (3, 7):
+            browsers_json = resources.files(__name__) / "browsers.json"
+        else:
+            browsers_json = pathlib.Path(__file__).parent / "browsers.json"
+
+        with browsers_json.open("r") as fp:
             user_agents = json.load(
                 fp,
                 object_pairs_hook=OrderedDict


### PR DESCRIPTION
If `cloudscraper` is embedded in a zip (e.g. `zipapp`), you can't use paths to load the `browsers.json` file, so importing the library fails.  `importlib.resources` allows this to work, but was added in Python 3.7.  I saw that you had back to Python 3.5 in `tox.ini`, so I added a switch to use the old behaviour prior to 3.7.